### PR TITLE
Upgrade Jewel to 0.15.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
                 implementation("com.fifesoft:rsyntaxtextarea:${extra["rsyntaxtextarea.version"] as String}")
                 implementation("com.fifesoft:rstaui:${extra["rstaui.version"] as String}")
                 implementation("net.java.dev.jna:jna:${extra["jna.version"] as String}")
+                implementation("androidx.collection:collection:${extra["collections.version"] as String}")
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 kotlin.code.style=official
 kotlin.version=1.9.21
 agp.version=7.3.0
-compose.version=1.5.11
+compose.version=1.6.10-dev1490
 rsyntaxtextarea.version=3.3.4
 rstaui.version=3.3.1
-skiko.version=0.7.90
-jewel.version=0.12.0
+skiko.version=0.7.97
+jewel.version=0.15.2
 jna.version=5.13.0
+collections.version=1.4.0


### PR DESCRIPTION
This includes upgrading Compose to 1.6.10-dev1490 (the version Jewel 0.15.2 depends on), and includes the addition of androidx.collection:collection:1.4.0 as the upgraded Compose version now relies on data structures in such dependency.