### PR TITLE
[Refactor] Simplify Splitter Related Code

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/DocumentChangeListener.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/DocumentChangeListener.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2023 Romain Guy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.romainguy.kotlin.explorer
+
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
+
+/**
+ * A [DocumentListener] that takes a single lambda that's invoked on any change
+ */
+class DocumentChangeListener(private val block: (DocumentEvent) -> Unit) : DocumentListener {
+    override fun insertUpdate(event: DocumentEvent) {
+        block(event)
+    }
+
+    override fun removeUpdate(event: DocumentEvent) {
+        block(event)
+    }
+
+    override fun changedUpdate(event: DocumentEvent) {
+        block(event)
+    }
+}

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Splitter.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Splitter.kt
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
+@file:Suppress("FunctionName", "OPT_IN_USAGE", "KotlinRedundantDiagnosticSuppress")
 @file:OptIn(ExperimentalSplitPaneApi::class)
 
 package dev.romainguy.kotlin.explorer
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.splitpane.ExperimentalSplitPaneApi
+import org.jetbrains.compose.splitpane.HorizontalSplitPane
 import org.jetbrains.compose.splitpane.SplitterScope
+import org.jetbrains.compose.splitpane.rememberSplitPaneState
 import java.awt.Cursor
 
 private fun Modifier.cursorForHorizontalResize(): Modifier =
@@ -46,5 +50,31 @@ fun SplitterScope.HorizontalSplitter() {
                 .width(5.dp)
                 .fillMaxHeight()
         )
+    }
+}
+
+@Composable
+fun ThreeWaySplitter(
+    modifier: Modifier = Modifier,
+    panel1: @Composable () -> Unit,
+    panel2: @Composable () -> Unit,
+    panel3: @Composable () -> Unit,
+) {
+    HorizontalSplitPane(
+        modifier = modifier,
+        splitPaneState = rememberSplitPaneState(initialPositionPercentage = 1.0f / 3)
+    ) {
+        first { panel1() }
+        second {
+            HorizontalSplitPane(
+                modifier = modifier,
+                splitPaneState = rememberSplitPaneState(initialPositionPercentage = 1.0f / 2)
+            ) {
+                first { panel2() }
+                second { panel3() }
+                splitter { HorizontalSplitter() }
+            }
+        }
+        splitter { HorizontalSplitter() }
     }
 }


### PR DESCRIPTION
* Don't use a mutableStateOf for the RSyntaxTextArea.
* Extract code creating the various RSyntaxTextArea components to methods
* Extract the code for creating the text areas Composables to methods
* Extract a 3-way splitter method
* Add a DocumentListener that takes a single lambda