### PR TITLE
Change Settings Screen to a Popup Dialog

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Menu.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Menu.kt
@@ -46,6 +46,6 @@ fun MenuScope.MenuCheckboxItem(
 }
 
 @Composable
-fun MenuScope.MenuItem(text: String, shortcut: Shortcut, onClick: () -> Unit) {
-    Item(text, shortcut = shortcut.asKeyShortcut(), onClick = onClick)
+fun MenuScope.MenuItem(text: String, shortcut: Shortcut, onClick: () -> Unit, enabled: Boolean = true) {
+    Item(text, enabled = enabled, shortcut = shortcut.asKeyShortcut(), onClick = onClick)
 }

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Paths.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Paths.kt
@@ -24,6 +24,11 @@ import kotlin.io.path.extension
 import kotlin.jvm.optionals.getOrElse
 
 class ToolPaths(settingsDirectory: Path, androidHome: Path, kotlinHome: Path) {
+    constructor(settingsDirectory: Path, androidHome: String, kotlinHome: String) : this(
+        settingsDirectory,
+        Path.of(androidHome),
+        Path.of(kotlinHome)
+    )
     val tempDirectory = Files.createTempDirectory("kotlin-explorer")!!
     val platform: Path
     val d8: Path

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/State.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/State.kt
@@ -40,7 +40,7 @@ private const val Placement = "WINDOW_PLACEMENT"
 
 @Stable
 class ExplorerState {
-    private val directory = settingsPath()
+    val directory: Path = settingsPath()
     private val file: Path = directory.resolve("settings")
     private val entries: MutableMap<String, String> = readSettings(file)
 

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/SwingPanel.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/SwingPanel.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Romain Guy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("FunctionName")
+
+package dev.romainguy.kotlin.explorer
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.NoOpUpdate
+import androidx.compose.ui.awt.SwingPanel
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import java.awt.Component
+import java.awt.GraphicsEnvironment
+import java.awt.image.BufferedImage
+
+
+/**
+ * A [SwingPanel] that supports a Dialog rendered over it
+ *
+ * When [isDialogVisible] is true, the panel captures a screenshot its [Component] and renders an [Image] instead of
+ * the actual [SwingPanel]. The [SwingPanel] is still rendered in order to keep it attached to the component hierarchy.
+ */
+@Composable
+fun <T : Component> DialogSupportingSwingPanel(
+    background: Color = Color.White,
+    factory: () -> T,
+    modifier: Modifier = Modifier,
+    update: (T) -> Unit = NoOpUpdate,
+    isDialogVisible: Boolean,
+) {
+    val component = remember { factory() }
+
+    Column(modifier = modifier) {
+        val fillMaxSize = Modifier.fillMaxSize()
+        if (isDialogVisible) {
+            val bitmap = remember { component.getScreenShot()?.toComposeImageBitmap() }
+            if (bitmap != null) {
+                Image(bitmap = bitmap, contentDescription = "", modifier = fillMaxSize)
+            } else {
+                Box(modifier = fillMaxSize)
+            }
+        }
+        SwingPanel(background, { component }, fillMaxSize, update)
+    }
+}
+
+fun Component.getScreenShot(): BufferedImage? {
+    if (width == 0 || height == 0) {
+        return null
+    }
+    val config = GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice.defaultConfiguration
+    val image = config.createCompatibleImage(width, height)
+    paint(image.graphics)
+    return image
+}


### PR DESCRIPTION
SwingPanel doesn't work with Dialogs so I added DialogSupportingSwingPanel which works around the problem by grabbing a screenshot of its component and rendering an Image when the dialog is visible.

Some more changes were made to work better with a popup:

* Wrap the settings with a Material Card
* Add a Cancel button
* Move buttons to the bottom right
* Update the icons on the fly
* Disable the Save button if paths are invalid
* Allow dismissing the dialog with an invalid state but disable the Compile menu item. This should only be possible on first run.


![image](https://github.com/romainguy/kotlin-explorer/assets/1660304/19368c6a-226b-4eef-986e-5133d617050f)
