### PR TITLE
Fix Linux Issue With SwingPanel

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/SwingPanel.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/SwingPanel.kt
@@ -20,6 +20,7 @@ package dev.romainguy.kotlin.explorer
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -52,18 +53,19 @@ fun <T : Component> DialogSupportingSwingPanel(
     // See https://github.com/JetBrains/compose-multiplatform-core/pull/915
     // macOS should work, but it doesn't quite yet, mouse events get dispatched only to the Swing panel below
     if (isLinux || isMac) {
-        Box(modifier = modifier) {
-            if (isDialogVisible) {
+        if (isDialogVisible) {
+            Column(modifier = modifier) {
                 val bitmap = remember { component.getScreenShot()?.toComposeImageBitmap() }
                 if (bitmap != null) {
                     Image(bitmap = bitmap, contentDescription = "", modifier = Modifier.fillMaxSize())
+                } else {
+                    Box(modifier.fillMaxSize())
                 }
-            } else {
-                SwingPanel(background, { component }, Modifier.fillMaxSize(), update)
             }
         }
+        SwingPanel(background, { component }, modifier = Modifier.fillMaxSize(), update)
     } else {
-        SwingPanel(background, { component }, Modifier.fillMaxSize(), update)
+        SwingPanel(background, { component }, modifier, update)
     }
 }
 


### PR DESCRIPTION
On Linux, we must render a SwingPanel below the Image. Otherwise, we log an exception:

```
Exception in thread "AWT-EventQueue-0" java.lang.ArrayIndexOutOfBoundsException: No such child: 3
        at java.desktop/java.awt.Container.getComponent(Container.java:354)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:898)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1131)
        at java.desktop/javax.swing.JLayeredPane.paint(JLayeredPane.java:586)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:955)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1131)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:955)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1131)
        at java.desktop/javax.swing.JLayeredPane.paint(JLayeredPane.java:586)
        at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:955)
        at java.desktop/javax.swing.JComponent.paint(JComponent.java:1131)
        at java.desktop/javax.swing.JComponent.paintToOffscreen(JComponent.java:5319)
        at java.desktop/javax.swing.RepaintManager$PaintManager.paintDoubleBufferedImpl(RepaintManager.java:1668)
        at java.desktop/javax.swing.RepaintManager$PaintManager.paintDoubleBuffered(RepaintManager.java:1643)
        at java.desktop/javax.swing.RepaintManager$PaintManager.paint(RepaintManager.java:1580)
        at java.desktop/javax.swing.BufferStrategyPaintManager.paint(BufferStrategyPaintManager.java:262)
        at java.desktop/javax.swing.RepaintManager.paint(RepaintManager.java:1347)
        at java.desktop/javax.swing.JComponent._paintImmediately(JComponent.java:5267)
        at java.desktop/javax.swing.JComponent.paintImmediately(JComponent.java:5077)
        at java.desktop/javax.swing.RepaintManager$4.run(RepaintManager.java:882)
        at java.desktop/javax.swing.RepaintManager$4.run(RepaintManager.java:865)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
        at java.desktop/javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:865)
        at java.desktop/javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:838)
        at java.desktop/javax.swing.RepaintManager.prePaintDirtyRegions(RepaintManager.java:787)
        at java.desktop/javax.swing.RepaintManager$ProcessingRunnable.run(RepaintManager.java:1909)
        at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:779)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:730)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:724)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:749)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```