### PR TITLE
Add Indent & Line Number Width to Settings

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/State.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/State.kt
@@ -33,6 +33,8 @@ private const val ShowLineNumbers = "SHOW_LINE_NUMBERS"
 private const val ShowByteCode = "SHOW_BYTE_CODE"
 private const val ShowDex = "SHOW_DEX"
 private const val ShowOat = "SHOW_OAT"
+private const val Indent = "Indent"
+private const val LineNumberWidth = "LINE_NUMBER_WIDTH"
 private const val WindowPosX = "WINDOW_X"
 private const val WindowPosY = "WINDOW_Y"
 private const val WindowWidth = "WINDOW_WIDTH"
@@ -54,6 +56,8 @@ class ExplorerState {
     var showByteCode by BooleanState(ShowByteCode, false)
     var showDex by BooleanState(ShowDex, true)
     var showOat by BooleanState(ShowOat, true)
+    var lineNumberWidth by IntState(LineNumberWidth, 4)
+    var indent by IntState(Indent, 4)
     var sourceCode: String = readSourceCode(toolPaths)
     var windowWidth by IntState(WindowWidth, 1900)
     var windowHeight by IntState(WindowHeight, 1600)

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/code/Code.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/code/Code.kt
@@ -16,7 +16,6 @@
 
 package dev.romainguy.kotlin.explorer.code
 
-import dev.romainguy.kotlin.explorer.code.CodeBuilder.LineNumberMode
 
 /**
  * A data model representing disassembled code
@@ -25,13 +24,13 @@ import dev.romainguy.kotlin.explorer.code.CodeBuilder.LineNumberMode
  * * Disassembled text with optional line number annotations
  * * Jump information for branch instructions
  */
-class Code(private val classes: List<Class>, indent: Int, lineNumberMode: LineNumberMode) {
+class Code(private val classes: List<Class>, codeStyle: CodeStyle) {
     private val jumps: Map<Int, Int>
 
     val text: String
 
     init {
-        val code = buildCode(indent, lineNumberMode) {
+        val code = buildCode(codeStyle) {
             classes.forEach { clazz ->
                 startClass(clazz)
                 clazz.methods.forEach { method ->

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/code/CodeStyle.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/code/CodeStyle.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 Romain Guy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.romainguy.kotlin.explorer.code
+
+data class CodeStyle(
+    val indent: Int,
+    val showLineNumbers: Boolean,
+    val lineNumberWidth: Int,
+    )


### PR DESCRIPTION
The indent only works for the decompiled code windows, not for the source.

It would be nice to be able to do that but RSyntaxTextArea doesn't really support reformating based on indent level.