### PR TITLE
Launch Some Task in Parallel to Speed Things Up

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/KotlinExplorer.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/KotlinExplorer.kt
@@ -240,7 +240,7 @@ private fun LogsPanel(logs: String) {
 @Composable
 private fun StatusBar(status: String, progress: Float) {
     Row(verticalAlignment = CenterVertically) {
-        val width = 190.dp
+        val width = 220.dp
         Text(
             modifier = Modifier
                 .widthIn(min = width, max = width)

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Logger.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/Logger.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2023 Romain Guy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.romainguy.kotlin.explorer
+
+private const val Debug = 1
+private const val Warning = 2
+
+object Logger {
+    private val level = System.getenv("KOTLIN_EXPLORER_LOG")?.toIntOrNull() ?: 0
+
+    fun debug(message: String) {
+        if (level >= Debug) {
+            println("Debug:  $message")
+        }
+    }
+
+    fun warn(message: String) {
+        if (level >= Warning) {
+            println("Warning: $message")
+        }
+    }
+}

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/ProgressUpdater.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/ProgressUpdater.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Romain Guy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.romainguy.kotlin.explorer
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Helps manage updates to a status bar */
+class ProgressUpdater(
+    val steps: Int,
+    private val onUpdate: (String, Float) -> Unit,
+) {
+    private val stepCounter = AtomicInteger(0)
+    private val jobs = mutableListOf<Job>()
+
+    /** Update without advancing progress */
+    fun update(message: String) {
+        sendUpdate(message, stepCounter.get())
+    }
+
+    /**
+     * Update and advance progress
+     *
+     * We can advance by more than one step, for example, if a step fails and that prevents the next 3 steps from being
+     * able to run, we would advance by 4.
+     */
+    fun advance(message: String, steps: Int = 1) {
+        sendUpdate(message, stepCounter.addAndGet(steps))
+    }
+
+    /**
+     * Joins all threads and sends the last update
+     */
+    suspend fun finish() {
+        jobs.joinAll()
+        val step = stepCounter.get()
+        if (step < steps) {
+            Logger.warn("finish() called but progress is not yet finished: step=$step")
+        }
+        sendUpdate("Ready", steps)
+    }
+
+    /** Add a job that needs to be joined before finishing*/
+    fun addJob(job: Job) {
+        jobs.add(job)
+    }
+
+    private fun sendUpdate(message: String, step: Int) {
+        if (step > steps) {
+            Logger.warn("Progress already completed while sending: '$message'")
+        }
+        Logger.debug("Sending $step/$steps: '$message'")
+        onUpdate(message, step.toFloat() / steps)
+    }
+
+}


### PR DESCRIPTION
`javap` and `dexdump` can be launched in the background while we continue processing.

I changed the semantics of Status to show what has already been done, rather that's being done now. This is because now, things can happen at the same time. For example:

`Creating Java ByteCode` & `Creating Dex Dump` would be set at almost the same time and we wouldn't see one of them.

I'm using an `AtomicFloat` to guard the step counter and I changed some of the `launch(ui)` to `withContext(ui)` where it wasn't blocking further processing.

Note that now, if javap or dexdump fails, we keep going so we don't set the progress to Done. I extracted the `onStatusUpdate()` for success and failure to a single call so we can easily see how many times we call getAndIncrement