### PR TITLE
Fix classpath generation with android.jar for kotlinc

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
@@ -33,7 +33,7 @@ class KotlinCompiler(private val toolPaths: ToolPaths, private val outputDirecto
             "-Xno-call-assertions",
             "-Xno-receiver-assertions",
             "-classpath",
-            (toolPaths.kotlinLibs + toolPaths.platform).joinToString(":") { jar -> jar.toString() }
+            (toolPaths.kotlinLibs + listOf(toolPaths.platform)).joinToString(":") { jar -> jar.toString() }
         )
 
         return command.toTypedArray()


### PR DESCRIPTION
Path is also Iterable, so we got a list that consisted of separate directories leading to android.jar that were separated by a colon, as a result of which the Kotlin compilation did not work