### PR TITLE
Mention ./gradlew jvmRun in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ which panels are visible using the *View* menu.
 
 # Running Kotlin Explorer
 
+Kotlin Explorer is a Compose Desktop application. Run it with `./gradlew run`.
+
 Kotlin Explorer needs to be told where to find the Android SDK and the Kotlin compiler.
 Unless you've set `$ANDROID_HOME` and `$KOTLIN_HOME` properly, Kotlin Explorer will ask
 you to enter the path to those directories.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ which panels are visible using the *View* menu.
 
 # Running Kotlin Explorer
 
-Kotlin Explorer is a Compose Desktop application. Run it with `./gradlew run`.
+Run Kotlin Explorer with `./gradlew jvmRun`.
 
 Kotlin Explorer needs to be told where to find the Android SDK and the Kotlin compiler.
 Unless you've set `$ANDROID_HOME` and `$KOTLIN_HOME` properly, Kotlin Explorer will ask


### PR DESCRIPTION
I think this is the preferred way to run it? (As opposed to downloading binaries?)

See also https://github.com/romainguy/kotlin-explorer/issues/52