### PR TITLE
Fix Line Table Parsing in ByteCodeParser

### DIFF
--- a/src/jvmTest/kotlin/dev/romainguy/kotlin/explorer/bytecode/ByteCodeParserTest.kt
+++ b/src/jvmTest/kotlin/dev/romainguy/kotlin/explorer/bytecode/ByteCodeParserTest.kt
@@ -17,11 +17,14 @@
 package dev.romainguy.kotlin.explorer.bytecode
 
 import com.google.common.truth.Truth.assertThat
+import dev.romainguy.kotlin.explorer.code.Code
 import dev.romainguy.kotlin.explorer.testing.Builder
 import dev.romainguy.kotlin.explorer.testing.parseSuccess
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+import kotlin.io.path.readText
 
 class ByteCodeParserTest {
     @get:Rule
@@ -34,18 +37,23 @@ class ByteCodeParserTest {
     fun issue_45() {
         val content = byteCodeParser.parseSuccess(builder.generateByteCode("Issue_45.kt"))
 
-        assertThat(content.classes.map { it.header }).containsExactly(
-            "final class testData.Issue_45Kt\$main$1",
-            "public final class testData.Issue_45Kt",
-        )
-        assertThat(content.classes.flatMap { it.methods }.map { it.header }).containsExactly(
-            "testData.Issue_45Kt\$main\$1()",
-            "public final void invoke()",
-            "public java.lang.Object invoke()",
-            "public static final void main()",
-            "public static final void f1(kotlin.jvm.functions.Function0<kotlin.Unit>)",
-            "public static final void f2()",
-            "public static void main(java.lang.String[])",
-        )
+        val text = Code.fromClasses(content.classes).text
+
+        assertThat(text).isEqualTo(loadTestDataFile("Issue_45-Bytecode.expected"))
     }
+
+    @Test
+    fun tryCatch() {
+        val content = byteCodeParser.parseSuccess(builder.generateByteCode("TryCatch.kt"))
+
+        val text = Code.fromClasses(content.classes).text
+
+        assertThat(text).isEqualTo(loadTestDataFile("TryCatch-Bytecode.expected"))
+    }
+}
+
+fun loadTestDataFile(path: String): String {
+    val cwd = Path.of(System.getProperty("user.dir"))
+    val testData = cwd.resolve("src/jvmTest/kotlin/testData")
+    return testData.resolve(path).readText()
 }

--- a/src/jvmTest/kotlin/testData/Issue_45-Bytecode.expected
+++ b/src/jvmTest/kotlin/testData/Issue_45-Bytecode.expected
@@ -1,0 +1,47 @@
+final class testData.Issue_45Kt$main$1
+    testData.Issue_45Kt$main$1()
+        -- 4 instructions
+              0: aload_0
+              1: iconst_0
+              2: invokespecial #12 // Method kotlin/jvm/internal/Lambda."<init>":(I)V
+              5: return
+
+    public final void invoke()
+        -- 2 instructions
+        5:    0: invokestatic #20 // Method testData/Issue_45Kt.f2:()V
+        6:    3: return
+
+    public java.lang.Object invoke()
+        -- 4 instructions
+        4:    0: aload_0
+              1: invokevirtual #23 // Method invoke:()V
+              4: getstatic     #29 // Field kotlin/Unit.INSTANCE:Lkotlin/Unit;
+              7: areturn
+
+public final class testData.Issue_45Kt
+    public static final void main()
+        -- 4 instructions
+        4:    0: getstatic    #12 // Field testData/Issue_45Kt$main$1.INSTANCE:LtestData/Issue_45Kt$main$1;
+              3: checkcast    #14 // class kotlin/jvm/functions/Function0
+              6: invokestatic #18 // Method f1:(Lkotlin/jvm/functions/Function0;)V
+        7:    9: return
+
+    public static final void f1(kotlin.jvm.functions.Function0<kotlin.Unit>)
+        -- 4 instructions
+        9:    0: aload_0
+              1: invokeinterface #24,  1 // InterfaceMethod kotlin/jvm/functions/Function0.invoke:()Ljava/lang/Object;
+              6: pop
+              7: return
+
+    public static final void f2()
+        -- 5 instructions
+        11:   0: ldc           #29 // String Hi
+              2: getstatic     #35 // Field java/lang/System.out:Ljava/io/PrintStream;
+              5: swap
+              6: invokevirtual #41 // Method java/io/PrintStream.println:(Ljava/lang/Object;)V
+        12:   9: return
+
+    public static void main(java.lang.String[])
+        -- 2 instructions
+              0: invokestatic #44 // Method main:()V
+              3: return

--- a/src/jvmTest/kotlin/testData/TryCatch-Bytecode.expected
+++ b/src/jvmTest/kotlin/testData/TryCatch-Bytecode.expected
@@ -1,0 +1,23 @@
+public final class testData.TryCatchKt
+    public static final void main()
+        -- 9 instructions
+        4:    0: aconst_null
+              1: astore_0
+        5:    2: nop
+        6:    3: invokestatic  #11 // Method foo:()V
+              6: goto          16
+        8:    9: astore_1
+        9:    10: getstatic     #17 // Field java/lang/System.out:Ljava/io/PrintStream;
+              13: invokevirtual #22 // Method java/io/PrintStream.println:()V
+        11:   16: return
+
+    public static final void foo()
+        -- 3 instructions
+        14:   0: getstatic     #17 // Field java/lang/System.out:Ljava/io/PrintStream;
+              3: invokevirtual #22 // Method java/io/PrintStream.println:()V
+        15:   6: return
+
+    public static void main(java.lang.String[])
+        -- 2 instructions
+              0: invokestatic #29 // Method main:()V
+              3: return

--- a/src/jvmTest/kotlin/testData/TryCatch.javap
+++ b/src/jvmTest/kotlin/testData/TryCatch.javap
@@ -1,0 +1,45 @@
+Compiled from "TryCatch.kt"
+public final class testData.TryCatchKt {
+  public static final void main();
+    Code:
+       0: aconst_null
+       1: astore_0
+       2: nop
+       3: invokestatic  #11                 // Method foo:()V
+       6: goto          16
+       9: astore_1
+      10: getstatic     #17                 // Field java/lang/System.out:Ljava/io/PrintStream;
+      13: invokevirtual #22                 // Method java/io/PrintStream.println:()V
+      16: return
+    Exception table:
+       from    to  target type
+           2     6     9   Class java/lang/Exception
+    LineNumberTable:
+      line 4: 0
+      line 5: 2
+      line 6: 3
+      line 8: 9
+      line 9: 10
+      line 11: 16
+    LocalVariableTable:
+      Start  Length  Slot  Name   Signature
+         10       6     1     e   Ljava/lang/Exception;
+          2      15     0     a   Ljava/lang/Void;
+
+  public static final void foo();
+    Code:
+       0: getstatic     #17                 // Field java/lang/System.out:Ljava/io/PrintStream;
+       3: invokevirtual #22                 // Method java/io/PrintStream.println:()V
+       6: return
+    LineNumberTable:
+      line 14: 0
+      line 15: 6
+
+  public static void main(java.lang.String[]);
+    Code:
+       0: invokestatic  #29                 // Method main:()V
+       3: return
+    LocalVariableTable:
+      Start  Length  Slot  Name   Signature
+          0       4     0  args   [Ljava/lang/String;
+}

--- a/src/jvmTest/kotlin/testData/TryCatch.kt
+++ b/src/jvmTest/kotlin/testData/TryCatch.kt
@@ -1,0 +1,15 @@
+package testData
+
+fun main() {
+    val a = null
+    try {
+        foo()
+    }
+    catch (e: Exception) {
+        println()
+    }
+}
+
+fun foo() {
+    println()
+}


### PR DESCRIPTION
The existing code assumes that the line table comes right after the code section but this is not always the case.

For example, if there are try-catch blocks in the code, the exception table will come before the line table.