### PR TITLE
Update gmitch215/setup-java commit sha

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # TODO: replace this once https://github.com/actions/setup-java/pull/637 gets merged.
-      - uses: gmitch215/setup-java@99fc2135f7f7b08068e180cb5f29340f9de70720
+      - uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
         with:
           distribution: 'jetbrains'
           java-version: 17

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # TODO: replace this once https://github.com/actions/setup-java/pull/637 gets merged.
-      - uses: gmitch215/setup-java@99fc2135f7f7b08068e180cb5f29340f9de70720
+      - uses: gmitch215/setup-java@6d2c5e1f82f180ae79f799f0ed6e3e5efb4e664d
         with:
           distribution: 'jetbrains'
           java-version: 17


### PR DESCRIPTION
- Follow up #62.
- We forgot to update the commit sha in 3fe63c664ec1ca6ed7a7a42233be6dc9bc2b0a4d and 5d563fce87b57858ea13dc176d94e60541eb1ee7.