### PR TITLE
Prevent adding empty/blank `compilerFlags` to a compile command

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
@@ -36,8 +36,10 @@ class KotlinCompiler(private val toolPaths: ToolPaths, private val outputDirecto
             file.toString(),
             file.parent.resolve("Keep.kt").toString()
         ).apply {
-            // TODO: Do something smarter in case a flag looks like -foo="something with space"
-            addAll(compilerFlags.split(' '))
+            if (compilerFlags.isNotEmpty() || compilerFlags.isNotBlank()) {
+                // TODO: Do something smarter in case a flag looks like -foo="something with space"
+                addAll(compilerFlags.split(' '))
+            }
         }
 
         return command.toTypedArray()


### PR DESCRIPTION
Address the #73 issue.

As far as I debugged, adding an empty/blank string to a compile command results in a `ProcessResult` with an `exitCode` different than 0.