### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
@@ -17,6 +17,7 @@
 package dev.romainguy.kotlin.explorer.build
 
 import dev.romainguy.kotlin.explorer.ToolPaths
+import dev.romainguy.kotlin.explorer.isWindows
 import dev.romainguy.kotlin.explorer.process
 import java.nio.file.Path
 
@@ -34,7 +35,7 @@ class KotlinCompiler(private val toolPaths: ToolPaths, private val outputDirecto
             toolPaths.kotlinc.toString(),
             "-Xmulti-platform",
             "-classpath",
-            (toolPaths.kotlinLibs + listOf(toolPaths.platform)).joinToString(":") { jar -> jar.toString() }
+            (toolPaths.kotlinLibs + listOf(toolPaths.platform)).joinToString(if (isWindows) ";" else ":") { jar -> jar.toString() }
         ).apply {
             if (kotlinOnlyConsumers) {
                 this += "-Xno-param-assertions"

--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/build/KolinCompiler.kt
@@ -17,8 +17,8 @@
 package dev.romainguy.kotlin.explorer.build
 
 import dev.romainguy.kotlin.explorer.ToolPaths
-import dev.romainguy.kotlin.explorer.isWindows
 import dev.romainguy.kotlin.explorer.process
+import java.io.File
 import java.nio.file.Path
 
 private val BuiltInFiles = listOf(
@@ -35,7 +35,7 @@ class KotlinCompiler(private val toolPaths: ToolPaths, private val outputDirecto
             toolPaths.kotlinc.toString(),
             "-Xmulti-platform",
             "-classpath",
-            (toolPaths.kotlinLibs + listOf(toolPaths.platform)).joinToString(if (isWindows) ";" else ":") { jar -> jar.toString() }
+            (toolPaths.kotlinLibs + listOf(toolPaths.platform)).joinToString(File.pathSeparator) { jar -> jar.toString() }
         ).apply {
             if (kotlinOnlyConsumers) {
                 this += "-Xno-param-assertions"


### PR DESCRIPTION
`kotlinc` uses a different separator on Windows vs Mac/Linux for `-classpath`
https://kotlinlang.org/docs/compiler-reference.html#classpath-path-cp-path