### PR TITLE
Support Dependencies

### DIFF
--- a/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/DependencyCache.kt
+++ b/src/jvmMain/kotlin/dev/romainguy/kotlin/explorer/DependencyCache.kt
@@ -32,6 +32,10 @@ private const val BASE_PATH = "%1\$s/%2\$s/%3\$s/%2\$s-%3\$s"
 
 class DependencyCache(private val root: Path) {
 
+    fun getDependency(dependency: Dependency, onOutput: (String) -> Unit): Path {
+        return getDependency(dependency.group, dependency.name, dependency.version, onOutput)
+    }
+
     fun getDependency(group: String, name: String, version: String, onOutput: (String) -> Unit): Path {
         val basePath = BASE_PATH.format(group.replace('.', '/'), name, version)
         val dst = root.resolve("$basePath.jar")
@@ -89,4 +93,6 @@ class DependencyCache(private val root: Path) {
         }
         return true
     }
+
+    data class Dependency(val group: String, val name: String, val version: String)
 }


### PR DESCRIPTION
Allow code to specify required dependencies.

Dependencies are specified by adding comments like:

```
// dep: androidx.collection:collection-jvm:1.5.0
```

In the source file.