### PR TITLE
Replace deprecated macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        # The only available image for x86 is macos-13-large
-        # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
-        os: [ macos-13, macos-latest ]
+        os: [ macos-15-intel, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As of December 8, 2025, the `macos-13` image is no longer available, so it has been replaced by the `macos-15-intel` image (see https://github.com/actions/runner-images/issues/13046).